### PR TITLE
Add missing dependencies

### DIFF
--- a/impossible-case-alternative-repro.cabal
+++ b/impossible-case-alternative-repro.cabal
@@ -10,6 +10,8 @@ executable impossible-case-alternative-repro
       base >= 4 && <5
     , aeson
     , transformers-compat
+    , transformers
+    , semigroups
     , mtl
     , template-haskell
 


### PR DESCRIPTION
I can't reproduce the segfault (it just prints `Impossible case alternative`), but this was needed to get a successful cabal build with ghc-7.10.3.
